### PR TITLE
Fixed gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,7 @@ StyleCopReport.xml
 *_p.c
 *_h.h
 *.ilk
-*.meta
+#*.meta
 *.obj
 *.iobj
 *.pch


### PR DESCRIPTION
removed .meta that was interfering with object's properties in Unity